### PR TITLE
Killer-Specific strategy

### DIFF
--- a/src/constraint/reducible/killer.rs
+++ b/src/constraint/reducible/killer.rs
@@ -365,7 +365,8 @@ pub enum KillerReduction {
 /// raise an error if the cage contains cells outside the grid. `replace` maps
 /// the column and row of a cell to `None` if its content should not be
 /// replaced and to `Some(n)` if it should be replaced by n.
-fn check_cage(cage: &KillerCage, grid: &SudokuGrid, replace: impl Fn(usize, usize) -> Option<usize>) -> bool {
+fn check_cage(cage: &KillerCage, grid: &SudokuGrid,
+        replace: impl Fn(usize, usize) -> Option<usize>) -> bool {
     let size = grid.size();
     let mut numbers = USizeSet::new(1, size).unwrap();
     let mut sum = 0;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -148,7 +148,7 @@ enum Reduction<R, C: Constraint<Reduction = R> + Clone> {
     }
 }
 
-impl<R, C: Constraint<Reduction = R> + Clone> Reduction<R, C> {
+impl<R, C: Constraint<Reduction = R> + Clone + 'static> Reduction<R, C> {
     fn apply<S: Solver>(&self, sudoku: &mut Sudoku<C>, solution: &SudokuGrid,
             solver: &S) {
         match self {
@@ -222,7 +222,10 @@ impl<S: Solver, R: Rng> Reducer<S, R> {
     ///
     /// It is expected that the given `sudoku` is full, i.e. contains no empty
     /// cells.
-    pub fn reduce<C: Constraint + Clone>(&mut self, sudoku: &mut Sudoku<C>) {
+    pub fn reduce<C>(&mut self, sudoku: &mut Sudoku<C>)
+    where
+        C: Constraint + Clone + 'static
+    {
         let reductions = reductions(sudoku);
         let solution = sudoku.grid().clone();
 
@@ -372,7 +375,10 @@ mod tests {
     struct TopLeftSolver;
 
     impl Solver for TopLeftSolver {
-        fn solve(&self, sudoku: &Sudoku<impl Constraint + Clone>) -> Solution {
+        fn solve<C>(&self, sudoku: &Sudoku<C>) -> Solution
+        where
+            C: Constraint + Clone + 'static
+        {
             let size = sudoku.grid().size();
             let cells = size * size;
             let clues = sudoku.grid().count_clues();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,8 +490,14 @@ fn to_string(cell: &Option<usize>) -> String {
     }
 }
 
-pub(crate) fn index(column: usize, row: usize, size: usize) -> usize {
-    row * size + column
+pub(crate) fn index(column: usize, row: usize, size: usize)
+        -> SudokuResult<usize> {
+    if column < size || row < size {
+        Ok(row * size + column)
+    }
+    else {
+        Err(SudokuError::OutOfBounds)
+    }
 }
 
 fn parse_dimensions(code: &str) -> Result<(usize, usize), SudokuParseError> {
@@ -671,15 +677,8 @@ impl SudokuGrid {
     /// case, `SudokuError::OutOfBounds` is returned.
     pub fn get_cell(&self, column: usize, row: usize)
             -> SudokuResult<Option<usize>> {
-        let size = self.size();
-
-        if column >= size || row >= size {
-            Err(SudokuError::OutOfBounds)
-        }
-        else {
-            let index = index(column, row, size);
-            Ok(self.cells[index])
-        }
+        let index = index(column, row, self.size())?;
+        Ok(self.cells[index])
     }
 
     /// Indicates whether the cell at the specified position has the given
@@ -730,16 +729,12 @@ impl SudokuGrid {
     pub fn set_cell(&mut self, column: usize, row: usize, number: usize)
             -> SudokuResult<()> {
         let size = self.size();
-
-        if column >= size || row >= size {
-            return Err(SudokuError::OutOfBounds);
-        }
+        let index = index(column, row, size)?;
 
         if number == 0 || number > size {
             return Err(SudokuError::InvalidNumber);
         }
 
-        let index = index(column, row, size);
         self.cells[index] = Some(number);
         Ok(())
     }
@@ -761,13 +756,7 @@ impl SudokuGrid {
     /// case, `SudokuError::OutOfBounds` is returned.
     pub fn clear_cell(&mut self, column: usize, row: usize)
             -> SudokuResult<()> {
-        let size = self.size();
-
-        if column >= size || row >= size {
-            return Err(SudokuError::OutOfBounds);
-        }
-        
-        let index = index(column, row, size);
+        let index = index(column, row, self.size())?;
         self.cells[index] = None;
         Ok(())
     }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -68,7 +68,9 @@ pub trait Solver {
     /// prove that a Sudoku is impossible or uniquely solveable (either
     /// because it isn't or the solver is not powerful enough), they shall
     /// return `Solution::Ambiguous`.
-    fn solve(&self, sudoku: &Sudoku<impl Constraint + Clone>) -> Solution;
+    fn solve<C>(&self, sudoku: &Sudoku<C>) -> Solution
+    where
+        C: Constraint + Clone + 'static;
 }
 
 /// A perfect [Solver] which solves Sudoku by recursively testing all valid
@@ -80,8 +82,11 @@ pub trait Solver {
 pub struct BacktrackingSolver;
 
 impl BacktrackingSolver {
-    fn solve_rec(sudoku: &mut Sudoku<impl Constraint + Clone>, column: usize,
-            row: usize) -> Solution {
+    fn solve_rec<C>(sudoku: &mut Sudoku<C>, column: usize, row: usize)
+        -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         let size = sudoku.grid().size();
         let last_cell = row == size;
 
@@ -117,13 +122,19 @@ impl BacktrackingSolver {
         }
     }
 
-    fn solve(sudoku: &mut Sudoku<impl Constraint + Clone>) -> Solution {
+    fn solve<C>(sudoku: &mut Sudoku<C>) -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         BacktrackingSolver::solve_rec(sudoku, 0, 0)
     }
 }
 
 impl Solver for BacktrackingSolver {
-    fn solve(&self, sudoku: &Sudoku<impl Constraint + Clone>) -> Solution {
+    fn solve<C>(&self, sudoku: &Sudoku<C>) -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         let mut clone = sudoku.clone();
         BacktrackingSolver::solve(&mut clone)
     }
@@ -148,7 +159,7 @@ mod tests {
 
     fn test_solves_correctly<C>(puzzle: &str, solution: &str, constraint: C)
     where
-        C: Constraint + Clone
+        C: Constraint + Clone + 'static
     {
         let sudoku = Sudoku::parse(puzzle, constraint).unwrap();
         let solver = BacktrackingSolver;

--- a/src/solver/strategy/general.rs
+++ b/src/solver/strategy/general.rs
@@ -34,8 +34,10 @@ pub struct NakedSingleStrategy;
 
 impl Strategy for NakedSingleStrategy {
 
-    fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-            -> bool {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         let size = sudoku_info.size();
         let mut changed = false;
 
@@ -106,8 +108,10 @@ pub struct OnlyCellStrategy;
 
 impl Strategy for OnlyCellStrategy {
 
-    fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-            -> bool {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         let size = sudoku_info.size();
         let grid = sudoku_info.sudoku().grid();
         let groups = sudoku_info.sudoku().constraint().get_groups(grid);
@@ -276,8 +280,10 @@ fn find_tuples(sudoku_info: &SudokuInfo<impl Constraint + Clone>,
 
 impl<F: Fn(usize) -> usize> Strategy for TupleStrategy<F> {
 
-    fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-            -> bool {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         let mut changed = false;
         let grid = sudoku_info.sudoku().grid();
         let groups = sudoku_info.sudoku().constraint().get_groups(grid);
@@ -386,7 +392,7 @@ where
 /// reached, but at most `max_applications` times, if it is given.
 fn apply_continuation(max_applications: Option<usize>,
         continuation_strategy: &impl Strategy,
-        sudoku_info: &mut SudokuInfo<impl Constraint + Clone>) {
+        sudoku_info: &mut SudokuInfo<impl Constraint + Clone + 'static>) {
     match max_applications {
         None => {
             while continuation_strategy.apply(sudoku_info) { }
@@ -426,8 +432,10 @@ where
     FA: Fn(usize) -> Option<usize>,
     S: Strategy
 {
-    fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-            -> bool {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         let size = sudoku_info.size();
         let max_options = (self.max_options_computer)(size);
         let max_applications = (self.max_applications_computer)(size);
@@ -555,8 +563,10 @@ where
     FA: Fn(usize) -> Option<usize>,
     S: Strategy
 {
-    fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-            -> bool {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         let size = sudoku_info.size();
         let max_cells = (self.max_cells_computer)(size);
         let max_applications = (self.max_applications_computer)(size);
@@ -620,7 +630,10 @@ where
 pub struct NoStrategy;
 
 impl Strategy for NoStrategy {
-    fn apply(&self, _: &mut SudokuInfo<impl Constraint + Clone>) -> bool {
+    fn apply<C>(&self, _: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         false
     }
 }
@@ -650,8 +663,10 @@ impl<S1: Strategy, S2: Strategy> CompositeStrategy<S1, S2> {
 }
 
 impl<S1: Strategy, S2: Strategy> Strategy for CompositeStrategy<S1, S2> {
-    fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-            -> bool {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
         self.s1.apply(sudoku_info) | self.s2.apply(sudoku_info)
     }
 }
@@ -671,7 +686,7 @@ mod tests {
     use crate::constraint::DefaultConstraint;
     use crate::solver::strategy::SudokuInfo;
 
-    fn apply<C: Constraint + Clone, S: Strategy>(strategy: S,
+    fn apply<C: Constraint + Clone + 'static, S: Strategy>(strategy: S,
             sudoku_info: &mut SudokuInfo<C>, apply_once: bool) {
         while strategy.apply(sudoku_info) {
             if apply_once {
@@ -687,7 +702,7 @@ mod tests {
         weak_strategy: W, strong_strategy: S, apply_once: bool,
         test: impl Fn(&SudokuInfo<C>) -> bool)
     where
-        C: Constraint + Clone,
+        C: Constraint + Clone + 'static,
         W: Strategy,
         S: Strategy
     {

--- a/src/solver/strategy/mod.rs
+++ b/src/solver/strategy/mod.rs
@@ -72,8 +72,10 @@
 //! struct NakedOneStrategy;
 //!
 //! impl Strategy for NakedOneStrategy {
-//!     fn apply(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>)
-//!             -> bool {
+//!     fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+//!     where
+//!         C: Constraint + Clone + 'static
+//!     {
 //!         let size = sudoku_info.sudoku().grid().size();
 //!         let mut changed = false;
 //!

--- a/src/solver/strategy/solvers.rs
+++ b/src/solver/strategy/solvers.rs
@@ -28,7 +28,10 @@ impl<S: Strategy> StrategicSolver<S> {
 }
 
 impl<S: Strategy> Solver for StrategicSolver<S> {
-    fn solve(&self, sudoku: &Sudoku<impl Constraint + Clone>) -> Solution {
+    fn solve<C>(&self, sudoku: &Sudoku<C>) -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         let mut sudoku_info = SudokuInfo::from_sudoku(sudoku.clone());
 
         while !sudoku_info.sudoku().grid().is_full() &&
@@ -112,15 +115,20 @@ impl<S: Strategy> StrategicBacktrackingSolver<S> {
     }
 
     #[inline]
-    fn solve_rec_step(&self,
-            sudoku_info: &mut SudokuInfo<impl Constraint + Clone>,
-            column: usize, row: usize, number: usize) -> Solution {
+    fn solve_rec_step<C>(&self, sudoku_info: &mut SudokuInfo<C>,
+        column: usize, row: usize, number: usize) -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         sudoku_info.enter_cell(column, row, number)
             .unwrap();
         self.solve_rec(sudoku_info)
     }
 
-    fn solve_rec(&self, sudoku_info: &mut SudokuInfo<impl Constraint + Clone>) -> Solution {
+    fn solve_rec<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         while {
             if let Some(solution) = to_solution(sudoku_info.sudoku()) {
                 return solution;
@@ -174,7 +182,10 @@ impl<S: Strategy> StrategicBacktrackingSolver<S> {
 }
 
 impl<S: Strategy> Solver for StrategicBacktrackingSolver<S> {
-    fn solve(&self, sudoku: &Sudoku<impl Constraint + Clone>) -> Solution {
+    fn solve<C>(&self, sudoku: &Sudoku<C>) -> Solution
+    where
+        C: Constraint + Clone + 'static
+    {
         self.solve_rec(&mut SudokuInfo::from_sudoku(sudoku.clone()))
     }
 }

--- a/src/solver/strategy/specific/killer.rs
+++ b/src/solver/strategy/specific/killer.rs
@@ -1,0 +1,226 @@
+//! This module contains [Strategy] implementations specific to the
+//! [KillerConstraint]. They are re-exported in the
+//! [specific](crate::solver::strategy::specific) module, so they do not have
+//! to be referenced from this module directly.
+
+use crate::constraint::{
+    Constraint,
+    KillerCage,
+    KillerConstraint,
+    Subconstraint
+};
+use crate::solver::strategy::{Strategy, SudokuInfo};
+use crate::util::USizeSet;
+
+/// A [Strategy] specifically for the [KillerConstraint], which, for each cage,
+/// enumerates the possibilities and eliminates all options which are not used
+/// in at least one possibility.
+///
+/// As an example, consider the following Killer cage (in a Sudoku with the
+/// [DefaultConstraint](crate::constraint::DefaultConstraint) as well as the
+/// [KillerConstraint]):
+///
+/// ```text
+/// ╔═══════╤═══════╦═══════╤═══════╗
+/// ║╭8─────┼───────╫──────╮│       ║
+/// ║│  X   │   Y   ║   Y  ││       ║
+/// ║╰──────┼───────╫──────╯│       ║
+/// ╟───────┼───────╫───────┼───────╢
+/// ║       │       ║       │       ║
+/// ║       │       ║       │       ║
+/// ║       │       ║       │       ║
+/// ╠═══════╪═══════╬═══════╪═══════╣
+/// ║       │       ║       │       ║
+/// ║       │   4   ║       │       ║
+/// ║       │       ║       │       ║
+/// ╟───────┼───────╫───────┼───────╢
+/// ║       │       ║       │       ║
+/// ║       │       ║   4   │       ║
+/// ║       │       ║       │       ║
+/// ╚═══════╧═══════╩═══════╧═══════╝
+/// ```
+///
+/// This strategy would be able to deduce that the cell marked with `X` cannot
+/// be a 1. This is because that would require a 4 in either of the cells
+/// marked with Y, which is not possible due to the 4s in the lower two rows.
+pub struct KillerCagePossibilitiesStrategy;
+
+/// Recursively enters all options to build the required sum from the remaining
+/// cells into `new_options`.
+///
+/// # Arguments
+///
+/// * `missing`: A [USizeSet] for each missing cell containing its options.
+/// * `current_sum`: The sum accumulated so far from the previous cells, i.e.
+/// all cells that were already filled and all that have been inserted.
+/// * `required_sum`: The sum annotated at the cage.
+/// * `new_options`: A vector which contains one [USizeSet] for each remaining
+/// cell (same indices as `missing`). In this set all found options for that
+/// specific cell should be entered.
+/// * `numbers`: A [USizeSet] that contains all numbers that were already
+/// inserted into previous cells in the cage. Filled cells are not considered
+/// here, since those should not occur in the options in the first place.
+/// * `index`: The index of the cell to process at this recursion depth.
+fn find_options_rec(missing: &Vec<&USizeSet>, current_sum: usize,
+        required_sum: usize, new_options: &mut Vec<USizeSet>,
+        numbers: &mut USizeSet, index: usize) -> bool {
+    if index == missing.len() - 1 {
+        let required = required_sum - current_sum;
+
+        if missing[index].contains(required) && !numbers.contains(required) {
+            new_options[index].insert(required).unwrap();
+            return true;
+        }
+
+        return false;
+    }
+
+    let mut result = false;
+
+    for option in missing[index].iter() {
+        let next_sum = current_sum + option;
+
+        if next_sum >= required_sum {
+            // Options are in ascending order, so following options will only
+            // be worse.
+            break;
+        }
+
+        if numbers.contains(option) {
+            continue;
+        }
+
+        numbers.insert(option).unwrap();
+
+        if find_options_rec(missing, next_sum, required_sum, new_options,
+                numbers, index + 1) {
+            new_options[index].insert(option).unwrap();
+            result = true;
+        }
+
+        numbers.remove(option).unwrap();
+    }
+
+    result
+}
+
+fn find_options(missing: &Vec<&USizeSet>, current_sum: usize,
+        required_sum: usize, size: usize) -> Vec<USizeSet> {
+    let mut new_options = vec![USizeSet::new(1, size).unwrap(); missing.len()];
+    let mut numbers = USizeSet::new(1, size).unwrap();
+    find_options_rec(missing, current_sum, required_sum, &mut new_options,
+        &mut numbers, 0);
+    new_options
+}
+
+fn process_cage<C>(cage: &KillerCage, sudoku_info: &mut SudokuInfo<C>) -> bool
+where
+    C: Constraint + Clone + 'static
+{
+    let size = sudoku_info.size();
+    let mut numbers = USizeSet::new(1, size).unwrap();
+    let mut sum = 0;
+    let mut missing_options = Vec::new();
+    let mut missing_cells = Vec::new();
+
+    for &(column, row) in cage.group() {
+        if let Some(n) = sudoku_info.get_cell(column, row).unwrap() {
+            numbers.insert(n).unwrap();
+            sum += n;
+        }
+        else {
+            missing_options.push(
+                sudoku_info.get_options(column, row).unwrap());
+            missing_cells.push((column, row));
+        }
+    }
+
+    if missing_cells.is_empty() {
+        return false;
+    }
+
+    let new_options =
+        find_options(&missing_options, sum, cage.sum(), sudoku_info.size());
+    let mut changed = false;
+
+    for (new_options, &(column, row)) in new_options.iter().zip(missing_cells.iter()) {
+        let options =
+            sudoku_info.get_options_mut(column, row).unwrap();
+        changed |= options.intersect_assign(new_options).unwrap();
+    }
+
+    changed
+}
+
+impl Strategy for KillerCagePossibilitiesStrategy {
+    fn apply<C>(&self, sudoku_info: &mut SudokuInfo<C>) -> bool
+    where
+        C: Constraint + Clone + 'static
+    {
+        let c = sudoku_info.sudoku().constraint();
+
+        if let Some(killer) = c.get_subconstraint::<KillerConstraint>() {
+            let mut changed = false;
+            let cages = killer.cages().clone();
+
+            for cage in cages {
+                changed |= process_cage(&cage, sudoku_info);
+            }
+
+            changed
+        }
+        else {
+            panic!("KillerCageSumStrategy deployed on non-killer Sudoku.")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use crate::{Sudoku, SudokuGrid};
+    use crate::constraint::{
+        CompositeConstraint,
+        DefaultConstraint,
+        KillerCage,
+        KillerConstraint
+    };
+    use crate::solver::strategy::SudokuInfo;
+
+    type DefaultKillerConstraint =
+        CompositeConstraint<DefaultConstraint, KillerConstraint>;
+
+    fn killer_example() -> Sudoku<DefaultKillerConstraint> {
+        let grid = SudokuGrid::parse("2x2;
+             , , , ,\
+             , , , ,\
+             ,4, , ,\
+             , ,4, ").unwrap();
+        let mut killer_constraint = KillerConstraint::new();
+        let cage = KillerCage::new(vec![(0, 0), (1, 0), (2, 0)], 8).unwrap();
+        killer_constraint.add_cage(cage).unwrap();
+        let constraint =
+            CompositeConstraint::new(DefaultConstraint, killer_constraint);
+        Sudoku::new_with_grid(grid, constraint)
+    }
+
+    fn applied_killer_example() -> SudokuInfo<DefaultKillerConstraint> {
+        let mut sudoku_info = SudokuInfo::from_sudoku(killer_example());
+        assert!(KillerCagePossibilitiesStrategy.apply(&mut sudoku_info));
+        sudoku_info
+    }
+
+    #[test]
+    fn killer_cage_possibilities_strategy_excludes_due_to_sum() {
+        let sudoku_info = applied_killer_example();
+        assert!(!sudoku_info.get_options(0, 0).unwrap().contains(1));
+    }
+
+    #[test]
+    fn killer_cage_possibilities_strategy_excludes_due_to_repeat() {
+        let sudoku_info = applied_killer_example();
+        assert!(!sudoku_info.get_options(0, 0).unwrap().contains(3));
+    }
+}

--- a/src/solver/strategy/specific/killer.rs
+++ b/src/solver/strategy/specific/killer.rs
@@ -61,7 +61,7 @@ pub struct KillerCagePossibilitiesStrategy;
 /// inserted into previous cells in the cage. Filled cells are not considered
 /// here, since those should not occur in the options in the first place.
 /// * `index`: The index of the cell to process at this recursion depth.
-fn find_options_rec(missing: &Vec<&USizeSet>, current_sum: usize,
+fn find_options_rec(missing: &[&USizeSet], current_sum: usize,
         required_sum: usize, new_options: &mut Vec<USizeSet>,
         numbers: &mut USizeSet, index: usize) -> bool {
     if index == missing.len() - 1 {
@@ -104,8 +104,8 @@ fn find_options_rec(missing: &Vec<&USizeSet>, current_sum: usize,
     result
 }
 
-fn find_options(missing: &Vec<&USizeSet>, current_sum: usize,
-        required_sum: usize, size: usize) -> Vec<USizeSet> {
+fn find_options(missing: &[&USizeSet], current_sum: usize, required_sum: usize,
+        size: usize) -> Vec<USizeSet> {
     let mut new_options = vec![USizeSet::new(1, size).unwrap(); missing.len()];
     let mut numbers = USizeSet::new(1, size).unwrap();
     find_options_rec(missing, current_sum, required_sum, &mut new_options,

--- a/src/solver/strategy/specific/mod.rs
+++ b/src/solver/strategy/specific/mod.rs
@@ -1,0 +1,8 @@
+//! This module contains [Strategy](crate::solver::strategy::Strategy)
+//! implementations specific to individual
+//! [Constraint](crate::constraint::Constraint)s. All implementations are
+//! re-exported in this module.
+
+pub mod killer;
+
+pub use killer::KillerCagePossibilitiesStrategy;


### PR DESCRIPTION
Implemented a way for strategies to only apply to specific constraints.
Added a Killer Sudoku strategy that lists all possibilities for cages and removes all options that do not occur in one of those. This yields a huge performance improvement and should be sufficient to accept Killer
Sudoku into the benchmark suite soon.
Renamed the `impls` module in `strategy` to `general`. It now only contains strategies which apply to all constraints.
Refactored index computation to be nicer.
Processed a TODO in SudokuInfo for better style.