### PR TITLE
USizeSet relations

### DIFF
--- a/src/constraint/mod.rs
+++ b/src/constraint/mod.rs
@@ -302,7 +302,7 @@ pub trait Constraint {
     /// composite constraint.
     fn to_objects(&self) -> Vec<&dyn Any>
     where
-        Self : Sized + 'static
+        Self: Sized + 'static
     {
         vec![self]
     }
@@ -323,6 +323,16 @@ pub trait Subconstraint {
     /// and left-to-right for the
     /// [CompositeConstraint](crate::constraint::composite::CompositeConstraint).
     fn get_subconstraint<S: Constraint + Sized + 'static>(&self) -> Option<&S>;
+
+    /// Indicates whether this constraint has a sub-constraint of type `S`.
+    /// This is true, if and only if [Subconstraint::get_subconstraint] returns
+    /// a `Some(_)` variant.
+    fn has_subconstraint<S>(&self) -> bool
+    where
+        S: Constraint + Sized + 'static
+    {
+        self.get_subconstraint::<S>().is_some()
+    }
 }
 
 impl<C: Constraint + Sized + 'static> Subconstraint for C {

--- a/src/solver/strategy/general.rs
+++ b/src/solver/strategy/general.rs
@@ -260,13 +260,10 @@ fn find_tuples_rec(sudoku_info: &SudokuInfo<impl Constraint + Clone>,
             find_tuples_rec(sudoku_info, next_rest, max_size,
                 curr_tuple.clone(), accumulator);
             curr_tuple.add_cell(next_options, next_column, next_row);
-            find_tuples_rec(sudoku_info, next_rest, max_size, curr_tuple,
-                accumulator);
         }
-        else {
-            find_tuples_rec(sudoku_info, next_rest, max_size, curr_tuple,
-                accumulator);
-        }
+
+        find_tuples_rec(sudoku_info, next_rest, max_size, curr_tuple,
+            accumulator)
     }
 }
 


### PR DESCRIPTION
Added methods to chech disjointness, subset and superset relations to the USizeSet.
This may be useful for further development, and is also helpful API for custom strategies.