### PR TITLE
Implement Strategy for tuples.

### DIFF
--- a/src/solver/strategy/general.rs
+++ b/src/solver/strategy/general.rs
@@ -674,6 +674,36 @@ impl<S1: Strategy + Clone, S2: Strategy + Clone> Clone for CompositeStrategy<S1,
     }
 }
 
+macro_rules! tuple_impls {
+    ( $( $name:tt )+ ) => {
+        impl<$($name,)+> Strategy for ($($name,)+) where $($name: Strategy,)+
+        {
+            fn apply<Con>(&self, sudoku_info: &mut SudokuInfo<Con>) -> bool
+            where
+                Con: Constraint + Clone + 'static
+            {
+                // This is shadowing the types using an identifier of the same name.
+                #[allow(non_snake_case)]
+                let ($($name,)+) = self;
+                false $(| $name.apply(sudoku_info))+
+            }
+        }
+    };
+}
+
+tuple_impls! { A }
+tuple_impls! { A B }
+tuple_impls! { A B C }
+tuple_impls! { A B C D }
+tuple_impls! { A B C D E }
+tuple_impls! { A B C D E F }
+tuple_impls! { A B C D E F G }
+tuple_impls! { A B C D E F G H }
+tuple_impls! { A B C D E F G H I }
+tuple_impls! { A B C D E F G H I J }
+tuple_impls! { A B C D E F G H I J K }
+tuple_impls! { A B C D E F G H I J K L }
+
 #[cfg(test)]
 mod tests {
 

--- a/src/solver/strategy/solvers.rs
+++ b/src/solver/strategy/solvers.rs
@@ -228,7 +228,7 @@ mod tests {
     fn only_cell_strategy_solver() -> StrategicSolver<impl Strategy> {
         StrategicSolver::new(OnlyCellStrategy)
     }
-    
+
     fn complex_composite_strategy_solver() -> StrategicSolver<impl Strategy> {
         let strategy = CompositeStrategy::new(NakedSingleStrategy,
             CompositeStrategy::new(OnlyCellStrategy,

--- a/src/solver/strategy/solvers.rs
+++ b/src/solver/strategy/solvers.rs
@@ -207,7 +207,6 @@ mod tests {
     use crate::solver::strategy::{
         BoundedOptionsBacktrackingStrategy,
         BoundedCellsBacktrackingStrategy,
-        CompositeStrategy,
         NakedSingleStrategy,
         OnlyCellStrategy,
         TupleStrategy
@@ -222,36 +221,28 @@ mod tests {
     }
 
     fn complex_strategy_solver() -> StrategicSolver<impl Strategy> {
-        let strategy = CompositeStrategy::new(NakedSingleStrategy,
-            CompositeStrategy::new(OnlyCellStrategy,
-                CompositeStrategy::new(TupleStrategy::new(|_| 7),
-                    CompositeStrategy::new(
-                        BoundedOptionsBacktrackingStrategy::new(|_| 2,
-                            |_| Some(1), OnlyCellStrategy),
-                        BoundedCellsBacktrackingStrategy::new(|_| 2,
-                            |_| Some(1), OnlyCellStrategy)))));
-        StrategicSolver::new(strategy)
+        StrategicSolver::new((
+            NakedSingleStrategy,
+            OnlyCellStrategy,
+            TupleStrategy::new(|_| 7),
+            BoundedOptionsBacktrackingStrategy::new(|_| 2, |_| Some(1), OnlyCellStrategy),
+            BoundedCellsBacktrackingStrategy::new(|_| 2, |_| Some(1), OnlyCellStrategy),
+        ))
     }
 
-    fn complex_strategic_backtracking_solver()
-            -> StrategicBacktrackingSolver<impl Strategy> {
+    fn complex_strategic_backtracking_solver() -> StrategicBacktrackingSolver<impl Strategy> {
         // This solver is used in the benchmark, where an error was found.
 
-        StrategicBacktrackingSolver::new(CompositeStrategy::new(
-            CompositeStrategy::new(
-                NakedSingleStrategy, OnlyCellStrategy),
-            CompositeStrategy::new(
-                TupleStrategy::new(|size| size - 2),
-                CompositeStrategy::new(
-                    BoundedCellsBacktrackingStrategy::new(|size| size - 2,
-                        |_| Some(1), OnlyCellStrategy),
-                    BoundedOptionsBacktrackingStrategy::new(|_| 2,
-                        |_| Some(1), CompositeStrategy::new(
-                            NakedSingleStrategy, OnlyCellStrategy
-                        )
-                    )
-                )
-            )
+        StrategicBacktrackingSolver::new((
+            NakedSingleStrategy,
+            OnlyCellStrategy,
+            TupleStrategy::new(|size| size - 2),
+            BoundedCellsBacktrackingStrategy::new(|size| size - 2, |_| Some(1), OnlyCellStrategy),
+            BoundedOptionsBacktrackingStrategy::new(
+                |_| 2,
+                |_| Some(1),
+                (NakedSingleStrategy, OnlyCellStrategy),
+            ),
         ))
     }
 


### PR DESCRIPTION
Unfortunately it's not possible to have a `DynamicStrategy` type matching the `DynamicConstraint` type, because `Strategy` is not type-safe.

Implementing `Strategy` for tuples (up to 12) allows having many strategies at once without having to nest `CompositeStrategy`s.